### PR TITLE
Add install target for all the Fortran binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,5 +174,5 @@ foreach(item ${FORTRAN_PROGRAMS})
   add_executable(${current} "${item}")
   set_target_properties(${current} PROPERTIES OUTPUT_NAME "${program_name}")
   target_link_libraries(${current} surfex-static)
-
+  install(TARGETS ${current} DESTINATION bin)
 endforeach(item)


### PR DESCRIPTION
This PR creates the `make install` target, which moves all the produced binaries to `$CMAKE_INSTALL_PREFIX/bin`